### PR TITLE
BUGFIX: Audio popping and artifacts on midi on/off

### DIFF
--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -43,7 +43,12 @@ void CustomVoice::prepareToPlay(double sampleRate, int samplesPerBlock, int numO
     spec.sampleRate = sampleRate;
     spec.numChannels = numOutputChannels;
 
+    juce::ADSR::Parameters initADSR{
+        0.1f, 0.1f, 0.1f, 0.1f
+    };
+
     envelope.setSampleRate(sampleRate);
+    envelope.setParameters(initADSR);
     
     sineOsc.prepare(spec);
     sqOsc.prepare(spec);
@@ -69,6 +74,7 @@ void CustomVoice::prepareToPlay(double sampleRate, int samplesPerBlock, int numO
 
 // set ADSR envelope
 void CustomVoice::setADSR(juce::ADSR::Parameters parameters) {
+    envelope.reset();
     envelope.setParameters(parameters);
 }
 
@@ -90,23 +96,28 @@ void CustomVoice::setWave(int waveformNum) {
 }
 
 void CustomVoice::renderNextBlock(juce::AudioBuffer< float >& outputBuffer, int startSample, int numSamples) {
-    
-    // if voice is not currently playing a sound, clear note to allow voice to play another sound
-    synthBuffer.setSize(outputBuffer.getNumChannels(), outputBuffer.getNumSamples(), false, false, true);
-    
+
     // ALL AUDIO PROCESSING CODE HERE
+
+    // Initialize subset buffer
+    synthBuffer.setSize(outputBuffer.getNumChannels(), numSamples, false, false, true);
+    synthBuffer.clear();
+
     //// Alias to chunk of audio buffer
     juce::dsp::AudioBlock<float> audioBlock{ synthBuffer };
     // ProcessContextReplacing will fill audioBlock with processed data
     osc->process(juce::dsp::ProcessContextReplacing<float>(audioBlock));
     gain.process(juce::dsp::ProcessContextReplacing<float>(audioBlock));
-    envelope.applyEnvelopeToBuffer(synthBuffer, startSample, numSamples);
+
+    envelope.applyEnvelopeToBuffer(synthBuffer, 0, synthBuffer.getNumSamples());
 
     for (int channel = 0; channel < outputBuffer.getNumChannels(); ++channel)
     {
-        outputBuffer.addFrom(channel, startSample, synthBuffer, channel, 0, numSamples);
+        outputBuffer.addFrom(channel, startSample, synthBuffer, channel, 0, numSamples, 1.0f);
 
-        if (!envelope.isActive())
+        if (!envelope.isActive()) {
             clearCurrentNote();
+            envelope.reset();
+        }
     }
 }

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -103,16 +103,17 @@ void CustomVoice::renderNextBlock(juce::AudioBuffer< float >& outputBuffer, int 
     synthBuffer.setSize(outputBuffer.getNumChannels(), numSamples, false, false, true);
     synthBuffer.clear();
 
-    //// Alias to chunk of audio buffer
+    // Alias to chunk of audio buffer
     juce::dsp::AudioBlock<float> audioBlock{ synthBuffer };
     // ProcessContextReplacing will fill audioBlock with processed data
     osc->process(juce::dsp::ProcessContextReplacing<float>(audioBlock));
     gain.process(juce::dsp::ProcessContextReplacing<float>(audioBlock));
 
+    // Apply ADSR to entire subset buffer
     envelope.applyEnvelopeToBuffer(synthBuffer, 0, synthBuffer.getNumSamples());
 
-    for (int channel = 0; channel < outputBuffer.getNumChannels(); ++channel)
-    {
+    // Add all samples from subset buffer back to output
+    for (int channel = 0; channel < outputBuffer.getNumChannels(); ++channel) {
         outputBuffer.addFrom(channel, startSample, synthBuffer, channel, 0, numSamples, 1.0f);
 
         if (!envelope.isActive()) {

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -60,7 +60,6 @@ public:
 
     //==============================================================================
     // Public vars
-    float freqValue = 440.0f;
     juce::MidiKeyboardState keyState;
     
 

--- a/Subsynth.jucer
+++ b/Subsynth.jucer
@@ -2,7 +2,8 @@
 
 <JUCERPROJECT id="E2dFzH" name="Subsynth" projectType="audioplug" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="1" jucerFormatVersion="1"
-              pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn">
+              pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
+              pluginFormats="buildAU,buildStandalone,buildVST3">
   <MAINGROUP id="MmmQmm" name="Subsynth">
     <GROUP id="{72F69890-37C4-A7C0-CD11-0D045D68D964}" name="Source">
       <FILE id="HLE9jp" name="ADSRComponent.cpp" compile="1" resource="0"


### PR DESCRIPTION
This PR:

- Fixes an issue with audio popping/artifacts the occurred on certain midi note on/off events.
- Initializes the ADSR envelope with initial values in `prepareToPlay`.