### PR TITLE
Doc strings

### DIFF
--- a/Source/ADSRComponent.cpp
+++ b/Source/ADSRComponent.cpp
@@ -38,26 +38,40 @@ ADSRWheel& ADSRWheel::operator= (ADSRWheel& oldObj)
     return *this;
 }
 
+// Gets parameters of the associated rotary element
+//
+// @return The rotary parameters of its start and end angle
 juce::Slider::RotaryParameters ADSRWheel::getParams() const
 {
     return rotary.getRotaryParameters();
 }
 
+// Gets the text of the associated rotary's label
+//
+// @return The rotary's label text
 juce::String ADSRWheel::getLabelText() const
 {
     return rotaryLabel.getText();
 }
 
+// Gets the value of the rotary slider
+//
+// @return The value of the rotary slider
 double ADSRWheel::getValue()
 {
     return rotary.getValue();
 }
 
+// Gets the type that this slider represents (attack, decay,
+// sustain, release)
+//
+// @return Which ADSR element this rotary represents
 ADSR_Element ADSRWheel::getType()
 {
     return this->element;
 }
 
+// Sets the rotary slider's style
 void ADSRWheel::setRotaryStyle()
 {
     rotary.setSliderStyle (juce::Slider::Rotary);
@@ -70,6 +84,8 @@ void ADSRWheel::setRotaryStyle()
     rotaryLabel.attachToComponent (&rotary, false);
 }
 
+// Sets the dimensions of the ADSRWheel object. Typically called
+// when the components's width or height changes.
 void ADSRWheel::resized()
 {
     rotary.setBounds (10, 30, 75, 75);
@@ -109,6 +125,8 @@ void ADSRComponent::paint (juce::Graphics& g)
 {
 }
 
+// Sets the dimensions of the ADSRComponent object's children. 
+// Typically called when the components's width or height changes.
 void ADSRComponent::resized()
 {
     attackRotary.setBounds (0, 0, 100, 100);
@@ -117,6 +135,10 @@ void ADSRComponent::resized()
     releaseRotary.setBounds (300, 0, 100, 100);
 }
 
+// Listens for changes on the `slider` parameter and sets 
+// the appropriate ADSR rotary's value.
+//
+// @param slider: A slider object that is triggering the change event
 void ADSRComponent::sliderValueChanged (juce::Slider* slider)
 {
     if (slider == &(attackRotary.rotary))
@@ -137,6 +159,10 @@ void ADSRComponent::sliderValueChanged (juce::Slider* slider)
     }
 }
 
+// Gets the values from each of the children attack, decay, sustain, 
+// release ADSRWheels.
+//
+// @return The values bundled in a ADSR::Parameters object.
 juce::ADSR::Parameters ADSRComponent::getEnvelope()
 {
     juce::ADSR::Parameters params {

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -27,7 +27,6 @@ bool CustomVoice::canPlaySound (juce::SynthesiserSound* sound)
 // @param currentPitchWheelPosition: What the pitch wheel position should be for this note.
 void CustomVoice::startNote (int midiNoteNumber, float velocity, juce::SynthesiserSound* sound, int currentPitchWheelPosition)
 {
-    // midi input here
     osc->setFrequency (juce::MidiMessage::getMidiNoteInHertz (midiNoteNumber));
     envelope.noteOn();
 }

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -13,6 +13,7 @@
 // Indicates if this voice object is capable of playing the given sound.
 //
 // @param sound: A SynthesiserSound to be associated with this voice.
+// @return True if sound is not a nullptr, else false
 bool CustomVoice::canPlaySound (juce::SynthesiserSound* sound)
 {
     return dynamic_cast<CustomSound*> (sound) != nullptr;

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -120,8 +120,8 @@ void CustomVoice::setADSR (juce::ADSR::Parameters parameters)
     envelope.setParameters (parameters);
 }
 
-// Changes which active oscillator between sine, square, saw, and triangle the
-// voice is using.
+// Changes the active oscillator the voice is using between sine, square, 
+// saw, and triangle.
 //
 // @param waveformNum: An integer representation for sine, square, saw, and triangle
 // waveforms.
@@ -178,7 +178,7 @@ void CustomVoice::setFilter (int filterNum, float cutoff, float resonance)
     }
 }
 
-// Calls the setGainDecibels method on the gain data member. Self-explanitory.
+// Calls the setGainDecibels method on the gain data member. Self-explanatory.
 //
 // @param gainVal: the decibel value to be set.
 void CustomVoice::setGain (double gainVal)

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -55,7 +55,7 @@ void CustomVoice::controllerMoved (int controllerNumber, int newControllerValue)
 {
 }
 
-// Initializes and configures the various components of the voice which must be 
+// Initializes and configures the various components of the voice which must be
 // done before the voice can be used.
 //
 // @param sampleRate: The sample rate to be used in initialization. Typically the target
@@ -119,7 +119,7 @@ void CustomVoice::setADSR (juce::ADSR::Parameters parameters)
     envelope.setParameters (parameters);
 }
 
-// Changes which active oscillator between sine, square, saw, and triangle the 
+// Changes which active oscillator between sine, square, saw, and triangle the
 // voice is using.
 //
 // @param waveformNum: An integer representation for sine, square, saw, and triangle
@@ -188,13 +188,11 @@ void CustomVoice::setGain (double gainVal)
 // Produces/processes a block of audio samples into the output stream of the plug-in
 //
 // @param outputBuffer: An AudioBuffer object that will be sent to the output stream
-// @param startSample: the index in which the rendered block should be inserted into 
+// @param startSample: the index in which the rendered block should be inserted into
 // the outputBuffer
 // @param numSamples: The amount of samples that need to be rendered.
 void CustomVoice::renderNextBlock (juce::AudioBuffer<float>& outputBuffer, int startSample, int numSamples)
 {
-    // ALL AUDIO PROCESSING CODE HERE
-
     // Initialize subset buffer
     synthBuffer.setSize (outputBuffer.getNumChannels(), numSamples, false, false, true);
     synthBuffer.clear();

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -10,11 +10,20 @@
 
 #include "CustomVoice.h"
 
+// Indicates if this voice object is capable of playing the given sound.
+//
+// @param sound: A SynthesiserSound to be associated with this voice.
 bool CustomVoice::canPlaySound (juce::SynthesiserSound* sound)
 {
     return dynamic_cast<CustomSound*> (sound) != nullptr;
 }
 
+// Starts playing a note. Typically called automatically during the rendering callback.
+//
+// @param midiNoteNumber: The note to be played represented by its MIDI number.
+// @param velocity: A value indicating how quickly the note was released 0 (slow) to 1 (fast).
+// @param sound: The SynthesiserSound associated with this voice.
+// @param currentPitchWheelPosition: What the pitch wheel position should be for this note.
 void CustomVoice::startNote (int midiNoteNumber, float velocity, juce::SynthesiserSound* sound, int currentPitchWheelPosition)
 {
     // midi input here
@@ -22,6 +31,10 @@ void CustomVoice::startNote (int midiNoteNumber, float velocity, juce::Synthesis
     envelope.noteOn();
 }
 
+// Stops a playing note. Typically called automatically during the rendering callback.
+//
+// @param velocity: a value indicating how quickly the note was released 0 (slow) to 1 (fast)
+// @param allowTailOff: a flag indicating whether a note wants to tail-off or stop immediately.
 void CustomVoice::stopNote (float velocity, bool allowTailOff)
 {
     envelope.noteOff();
@@ -32,14 +45,23 @@ void CustomVoice::stopNote (float velocity, bool allowTailOff)
     }
 }
 
+// A pure virtual function requiring basic implementation for SynthesizerVoice inheritence. NYI.
 void CustomVoice::pitchWheelMoved (int newPitchWheelValue)
 {
 }
 
+// A pure virtual function requiring basic implementation for SynthesizerVoice inheritence. NYI.
 void CustomVoice::controllerMoved (int controllerNumber, int newControllerValue)
 {
 }
 
+// Initializes and configures the various components of the voice which must be 
+// done before the voice can be used.
+//
+// @param sampleRate: The sample rate to be used in initialization. Typically the target
+// sample rate of the owning object.
+// @param samplesPerBlock: the maximum expected number of samples that will be in each rendered block
+// @param numOutputChannels: The number of output channels for the plugin
 void CustomVoice::prepareToPlay (double sampleRate, int samplesPerBlock, int numOutputChannels)
 {
     // Create a spec to hold prep info for dsp objects
@@ -87,13 +109,21 @@ void CustomVoice::prepareToPlay (double sampleRate, int samplesPerBlock, int num
     setGain (-25.0);
 }
 
-// set ADSR envelope
+// Sets the attack, decay, sustain, release values of the volume envelope.
+//
+// @param params: A set of attack, decay sustain, release values in an ADSR::Parameters
+// object for the volume envelope to be set to.
 void CustomVoice::setADSR (juce::ADSR::Parameters parameters)
 {
     envelope.reset();
     envelope.setParameters (parameters);
 }
 
+// Changes which active oscillator between sine, square, saw, and triangle the 
+// voice is using.
+//
+// @param waveformNum: An integer representation for sine, square, saw, and triangle
+// waveforms.
 void CustomVoice::setWave (int waveformNum)
 {
     // set wave value
@@ -116,6 +146,13 @@ void CustomVoice::setWave (int waveformNum)
     }
 }
 
+// Sets the filter type, cutoff frequency, and resonance setting for the state
+// variable filter data member.
+//
+// @param filterNum: An integer representation of the filter type to be set low pass,
+// band pass, high pass.
+// @param cutoff: The cutoff frequency for the state variable filter in Hz.
+// @param resonance: The amount of resonance to be applied by the state variable filter
 void CustomVoice::setFilter (int filterNum, float cutoff, float resonance)
 {
     if (filterNum == 1)
@@ -140,11 +177,20 @@ void CustomVoice::setFilter (int filterNum, float cutoff, float resonance)
     }
 }
 
+// Calls the setGainDecibels method on the gain data member. Self-explanitory.
+//
+// @param gainVal: the decibel value to be set.
 void CustomVoice::setGain (double gainVal)
 {
     gain.setGainDecibels (gainVal);
 }
 
+// Produces/processes a block of audio samples into the output stream of the plug-in
+//
+// @param outputBuffer: An AudioBuffer object that will be sent to the output stream
+// @param startSample: the index in which the rendered block should be inserted into 
+// the outputBuffer
+// @param numSamples: The amount of samples that need to be rendered.
 void CustomVoice::renderNextBlock (juce::AudioBuffer<float>& outputBuffer, int startSample, int numSamples)
 {
     // ALL AUDIO PROCESSING CODE HERE

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -194,6 +194,7 @@ void CustomVoice::setGain (double gainVal)
 // @param numSamples: The amount of samples that need to be rendered.
 void CustomVoice::renderNextBlock (juce::AudioBuffer<float>& outputBuffer, int startSample, int numSamples)
 {
+
     // Initialize subset buffer
     synthBuffer.setSize (outputBuffer.getNumChannels(), numSamples, false, false, true);
     synthBuffer.clear();

--- a/Source/CustomVoice.cpp
+++ b/Source/CustomVoice.cpp
@@ -223,6 +223,8 @@ void CustomVoice::renderNextBlock (juce::AudioBuffer<float>& outputBuffer, int s
     
 }
 
+// Runs a set of unit-style tests related to methods changing DSP 
+// component parameters. Must attach a debugger for proper function.
 void CustomVoice::voiceTests()
 {
 

--- a/Source/CustomVoice.h
+++ b/Source/CustomVoice.h
@@ -23,8 +23,6 @@ public:
     void renderNextBlock (juce::AudioBuffer<float>& outputBuffer, int startSample, int numSamples) override;
     void prepareToPlay (double sampleRate, int samplesPerBlock, int numOutputChannels);
 
-    // adsr functions
-    juce::ADSR::Parameters setADSRParams (float att, float dec, float sus, float rel);
     void setADSR (juce::ADSR::Parameters params);
     void setWave (int waveformNum);
     void setGain (double gain);

--- a/Source/CustomVoice.h
+++ b/Source/CustomVoice.h
@@ -28,7 +28,6 @@ public:
     void setADSR (juce::ADSR::Parameters params);
     void setWave (int waveformNum);
     void setGain (double gain);
-
     void setFilter (int filterNum, float cutoff, float resonance);
 
     double sampleRateHolder = 0;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -13,9 +13,7 @@
 SubsynthAudioProcessorEditor::SubsynthAudioProcessorEditor (SubsynthAudioProcessor& p)
     : AudioProcessorEditor (&p), audioProcessor (p), keyboard (audioProcessor.keyState, juce::MidiKeyboardComponent::horizontalKeyboard)
 {
-    // Make sure that before the constructor has finished, you've set the
-    // editor's size to whatever you need it to be.
-    ///setSize (1000, 300);
+    // Set size of plugin and styling of interactive components
     setSize (850, 565);
 
     setGainStyle();
@@ -51,7 +49,7 @@ SubsynthAudioProcessorEditor::SubsynthAudioProcessorEditor (SubsynthAudioProcess
     filterRes.onDragEnd = [this]
     { filterChanged(); };
 
-    // Expose slider to UI/Editor
+    // Expose interactive elements to UI/Editor
     addAndMakeVisible (&waveSelect);
     addAndMakeVisible (&keyboard);
     addAndMakeVisible (&adsrSliders);
@@ -77,12 +75,20 @@ SubsynthAudioProcessorEditor::~SubsynthAudioProcessorEditor()
 {
 }
 
+// Listens for changes on the `slider` parameter and sets
+// the Gain rotary's value.
+//
+// @param slider: A slider object that is triggering the change event
 void SubsynthAudioProcessorEditor::sliderValueChanged (juce::Slider* slider)
 {
     if (slider == &gainSlide)
         audioProcessor.changeVolume (gainSlide.getValue());
 }
 
+// Listens for changes on the `combobox` parameter and sets
+// the changeWaveform method in the AudioProcessor.
+//
+// @param slider: A combobox object that is triggering the change event
 void SubsynthAudioProcessorEditor::comboBoxChanged (juce::ComboBox* combobox)
 {
     if (combobox == &(waveSelect))
@@ -91,17 +97,25 @@ void SubsynthAudioProcessorEditor::comboBoxChanged (juce::ComboBox* combobox)
     }
 }
 
+// Listens for mouse clicks and drags and calls the changeADSREnv method
+// at the end of the event.
+//
+// @param event: A mouse event triggering the change
 void SubsynthAudioProcessorEditor::mouseDrag (const juce::MouseEvent& event)
 {
     audioProcessor.changeADSREnv (adsrSliders.getEnvelope());
 }
 
+// Calls the changeFilter method in the AudioProcessor to set filter type,
+// cutoff frequency, and resonance value.
 void SubsynthAudioProcessorEditor::filterChanged()
 {
     audioProcessor.changeFilter (filterSelect.getSelectedId(), filterCutoff.getValue(), filterRes.getValue());
 }
 
-//==============================================================================
+// Draws the content of the method on the GUI
+//
+// @param g: The graphics context that must be used to do the drawing operations.
 void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
 {
     // (Our component is opaque, so we must completely fill the background with a solid colour)
@@ -126,6 +140,8 @@ void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
     g.drawText ("Resonance", 110, 125, 100, 30, juce::Justification::centred);
 }
 
+// Sets the dimensions of the plug-in's top level children.
+// Typically called when the plug-in's width or height changes.
 void SubsynthAudioProcessorEditor::resized()
 {
     // sets the position and size of the slider with arguments (x, y, width, height)

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -151,7 +151,7 @@ void SubsynthAudioProcessorEditor::resized()
     gainSlide.setBounds (700, 50, 100, 100);
 }
 
-// establish GUI configuration for gain rotary
+// Establishes GUI configuration for gain rotary
 void SubsynthAudioProcessorEditor::setGainStyle()
 {
     gainSlide.setSliderStyle (juce::Slider::Rotary);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -32,27 +32,24 @@ private:
     void sliderValueChanged (juce::Slider* slider) override;
     void comboBoxChanged (juce::ComboBox* combobox) override;
     void mouseDrag (const juce::MouseEvent& event) override;
-
     void setGainStyle();
-
     void filterChanged();
 
-    // This reference is provided as a quick way for your editor to
-    // access the processor object that created it.
     SubsynthAudioProcessor& audioProcessor;
 
     // UI elements
     juce::ComboBox waveSelect;
-
     juce::ComboBox filterSelect;
     juce::Slider filterCutoff;
     juce::Slider filterRes;
 
     // ADSR Envelope Components
     ADSRComponent adsrSliders;
+
     // Gain slider and label
     juce::Slider gainSlide;
     juce::Label gainLabel;
+
     // Keyboard
     juce::MidiKeyboardComponent keyboard;
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -190,8 +190,15 @@ void SubsynthAudioProcessor::setStateInformation (const void* data, int sizeInBy
     // whose contents will have been created by the getStateInformation() call.
 }
 
-//====== UI Component Callbacks ================================================
+/**
+* ============================= UI Callbacks ========================================
+*/
 
+ // Calls the setADSR CustomVoice method to change the attack, decay, sustain, release 
+ // values of the volume envelope on each voice instantiated within the synth data member.
+ //
+ // @param params: A set of attack, decay sustain, release values in an ADSR::Parameters
+ // object for the volume envelope to be set to.
 void SubsynthAudioProcessor::changeADSREnv (juce::ADSR::Parameters params)
 {
     for (int i = 0; i < synth.getNumVoices(); i++)
@@ -200,6 +207,11 @@ void SubsynthAudioProcessor::changeADSREnv (juce::ADSR::Parameters params)
     }
 }
 
+// Calls the setWave CustomVoice method to change the waveform being produced by 
+// the oscillator in each voice of the synth data member.
+//
+// @param waveformNum: An integer representation for sine, square, saw, and triangle
+// waveforms.
 void SubsynthAudioProcessor::changeWaveform (int waveformNum)
 {
     for (int i = 0; i < synth.getNumVoices(); i++)
@@ -208,6 +220,10 @@ void SubsynthAudioProcessor::changeWaveform (int waveformNum)
     }
 }
 
+// Calls the setGain CustomVoice method to change the gain being applied to
+// the audio buffer of each voice of the synth data member
+//
+// @param gain: A number, in decibels, the gain voice data member should be set to.
 void SubsynthAudioProcessor::changeVolume (double gain)
 {
     for (int i = 0; i < synth.getNumVoices(); i++)
@@ -216,6 +232,13 @@ void SubsynthAudioProcessor::changeVolume (double gain)
     }
 }
 
+// Calls the setFilter CustomVoice method to change the filter type, cutoff frequency,
+// and resonance of the state variable filter of each voice in the synth data member
+//
+// @param filterNum: An integer representation of the filter type to be set low pass,
+// band pass, high pass.
+// @param cutoff: The cutoff frequency for the state variable filter in Hz.
+// @param resonance: The amount of resonance to be applied by the state variable filter
 void SubsynthAudioProcessor::changeFilter (int filterNum, float cutoff, float resonance)
 {
     for (int i = 0; i < synth.getNumVoices(); i++)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -90,20 +90,10 @@ int SubsynthAudioProcessor::getCurrentProgram()
     return 0;
 }
 
-// Called by the host to change the current program. NYI, required template code.
-void SubsynthAudioProcessor::setCurrentProgram (int index)
-{
-}
-
 // Returns the name of a given program. NYI, required template code.
 const juce::String SubsynthAudioProcessor::getProgramName (int index)
 {
     return {};
-}
-
-// Called by the host to rename a program. NYI, required template code.
-void SubsynthAudioProcessor::changeProgramName (int index, const juce::String& newName)
-{
 }
 
 //==============================================================================
@@ -200,26 +190,6 @@ juce::AudioProcessorEditor* SubsynthAudioProcessor::createEditor()
 {
     return new SubsynthAudioProcessorEditor (*this);
 }
-
-//==============================================================================
-
-// The host will call this method when it wants to save the processor's internal state.
-// NYI, template code.
-void SubsynthAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
-{
-    // You should use this method to store your parameters in the memory block.
-    // You could do that either as raw data, or use the XML or ValueTree classes
-    // as intermediaries to make it easy to save and load complex data.
-}
-
-// This must restore the processor's state from a block of data previously created 
-// using getStateInformation(). NYI, template code.
-void SubsynthAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
-{
-    // You should use this method to restore your parameters from this memory block,
-    // whose contents will have been created by the getStateInformation() call.
-}
-
 
 //============================= UI Callbacks ========================================
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -34,12 +34,15 @@ SubsynthAudioProcessor::~SubsynthAudioProcessor()
 {
 }
 
-//==============================================================================
+// Returns the name of this processor.
+//
+// @return The name of the processor as a String obj.
 const juce::String SubsynthAudioProcessor::getName() const
 {
     return JucePlugin_Name;
 }
 
+// Returns true if the processor wants MIDI messages.
 bool SubsynthAudioProcessor::acceptsMidi() const
 {
 #if JucePlugin_WantsMidiInput
@@ -49,6 +52,7 @@ bool SubsynthAudioProcessor::acceptsMidi() const
 #endif
 }
 
+// Returns true if the processor produces MIDI messages.
 bool SubsynthAudioProcessor::producesMidi() const
 {
 #if JucePlugin_ProducesMidiOutput
@@ -58,6 +62,7 @@ bool SubsynthAudioProcessor::producesMidi() const
 #endif
 }
 
+// Returns true if this is a MIDI effect plug-in and does no audio processing.
 bool SubsynthAudioProcessor::isMidiEffect() const
 {
 #if JucePlugin_IsMidiEffect
@@ -67,36 +72,48 @@ bool SubsynthAudioProcessor::isMidiEffect() const
 #endif
 }
 
+// Returns the length of the processor's tail, in seconds. No tail used (0 seconds).
 double SubsynthAudioProcessor::getTailLengthSeconds() const
 {
     return 0.0;
 }
 
+// Returns the number of preset programs the processor supports. Always returns at least 1.
 int SubsynthAudioProcessor::getNumPrograms()
 {
     return 1; // NB: some hosts don't cope very well if you tell them there are 0 programs,
         // so this should be at least 1, even if you're not really implementing programs.
 }
 
+// Returns the number of the currently active program. Programs NYI, returns 0.
 int SubsynthAudioProcessor::getCurrentProgram()
 {
     return 0;
 }
 
+// Called by the host to change the current program. NYI, required template code.
 void SubsynthAudioProcessor::setCurrentProgram (int index)
 {
 }
 
+// Must return the name of a given program.
 const juce::String SubsynthAudioProcessor::getProgramName (int index)
 {
     return {};
 }
 
+// Called by the host to rename a program. NYI, required template code.
 void SubsynthAudioProcessor::changeProgramName (int index, const juce::String& newName)
 {
 }
 
 //==============================================================================
+
+// Called before playback starts, to let the processor prepare itself.
+//
+// @param sampleRate: Target sample rate
+// @param samplesPerBlock: A strong hint about the maximum number of samples 
+// that will be provided in each block.
 void SubsynthAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
     // Use this method as the place to do any pre-playback
@@ -109,6 +126,8 @@ void SubsynthAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlo
     wfVisualiser.clear();
 }
 
+// Called after playback has stopped, to let the object free up any 
+// resources it no longer needs.
 void SubsynthAudioProcessor::releaseResources()
 {
     // When playback stops, you can use this as an opportunity to free up any
@@ -116,7 +135,11 @@ void SubsynthAudioProcessor::releaseResources()
     keyState.reset();
 }
 
+
 #ifndef JucePlugin_PreferredChannelConfigurations
+// Callback to query if the AudioProcessor supports a specific layout.
+//
+// @param layouts: The bus layout to check
 bool SubsynthAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
 #if JucePlugin_IsMidiEffect
@@ -142,6 +165,10 @@ bool SubsynthAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts)
 }
 #endif
 
+// Renders the next audio block
+//
+// @param buffer: The buffer obj to use for rendering
+// @param midiMessages: The collected MIDI messages associated with this buffer.
 void SubsynthAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
     if (buffer.getNumSamples() == 0)
@@ -166,17 +193,23 @@ void SubsynthAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juc
 }
 
 //==============================================================================
+
+// Processor subclass must override this and return true if it can create an editor component.
 bool SubsynthAudioProcessor::hasEditor() const
 {
-    return true; // (change this to false if you choose to not supply an editor)
+    return true;
 }
 
+// Creates the processor's GUI via creating an AudioProcessorEditor
 juce::AudioProcessorEditor* SubsynthAudioProcessor::createEditor()
 {
     return new SubsynthAudioProcessorEditor (*this);
 }
 
 //==============================================================================
+
+// The host will call this method when it wants to save the processor's internal state.
+// NYI, template code.
 void SubsynthAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
     // You should use this method to store your parameters in the memory block.
@@ -184,15 +217,17 @@ void SubsynthAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
     // as intermediaries to make it easy to save and load complex data.
 }
 
+// This must restore the processor's state from a block of data previously created 
+// using getStateInformation(). NYI, template code.
 void SubsynthAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
 }
 
-/**
-* ============================= UI Callbacks ========================================
-*/
+
+//============================= UI Callbacks ========================================
+
 
  // Calls the setADSR CustomVoice method to change the attack, decay, sustain, release 
  // values of the volume envelope on each voice instantiated within the synth data member.

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -81,8 +81,7 @@ double SubsynthAudioProcessor::getTailLengthSeconds() const
 // Returns the number of preset programs the processor supports. Always returns at least 1.
 int SubsynthAudioProcessor::getNumPrograms()
 {
-    return 1; // NB: some hosts don't cope very well if you tell them there are 0 programs,
-        // so this should be at least 1, even if you're not really implementing programs.
+    return 1;
 }
 
 // Returns the number of the currently active program. Programs NYI, returns 0.
@@ -96,7 +95,7 @@ void SubsynthAudioProcessor::setCurrentProgram (int index)
 {
 }
 
-// Must return the name of a given program.
+// Returns the name of a given program. NYI, required template code.
 const juce::String SubsynthAudioProcessor::getProgramName (int index)
 {
     return {};

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -115,9 +115,6 @@ void SubsynthAudioProcessor::changeProgramName (int index, const juce::String& n
 // that will be provided in each block.
 void SubsynthAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
-    // Use this method as the place to do any pre-playback
-    // initialisation that you need..
-
     synth.setCurrentPlaybackSampleRate (sampleRate);
     for (int i = 0; i < synth.getNumVoices(); i++)
         (dynamic_cast<CustomVoice*> (synth.getVoice (i)))->prepareToPlay (sampleRate, samplesPerBlock, getTotalNumOutputChannels());
@@ -130,8 +127,6 @@ void SubsynthAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlo
 // resources it no longer needs.
 void SubsynthAudioProcessor::releaseResources()
 {
-    // When playback stops, you can use this as an opportunity to free up any
-    // spare memory, etc.
     keyState.reset();
 }
 
@@ -270,8 +265,8 @@ void SubsynthAudioProcessor::changeVolume (double gain)
 // Calls the setFilter CustomVoice method to change the filter type, cutoff frequency,
 // and resonance of the state variable filter of each voice in the synth data member
 //
-// @param filterNum: An integer representation of the filter type to be set low pass,
-// band pass, high pass.
+// @param filterNum: An integer representation of the filter type to be set; options
+// include low pass, band pass, and high pass.
 // @param cutoff: The cutoff frequency for the state variable filter in Hz.
 // @param resonance: The amount of resonance to be applied by the state variable filter
 void SubsynthAudioProcessor::changeFilter (int filterNum, float cutoff, float resonance)

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -282,6 +282,8 @@ void SubsynthAudioProcessor::changeFilter (int filterNum, float cutoff, float re
     }
 }
 
+// Runs a set of unit-style tests related to methods changing DSP
+// component parameters. Must attach a debugger for proper function.
 void SubsynthAudioProcessor::runTests()
 {
     CustomVoice testVoice;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -47,13 +47,13 @@ public:
     //==============================================================================
     int getNumPrograms() override;
     int getCurrentProgram() override;
-    void setCurrentProgram (int index) override;
+    void setCurrentProgram (int index) override {};
     const juce::String getProgramName (int index) override;
-    void changeProgramName (int index, const juce::String& newName) override;
+    void changeProgramName (int index, const juce::String& newName) override {};
 
     //==============================================================================
-    void getStateInformation (juce::MemoryBlock& destData) override;
-    void setStateInformation (const void* data, int sizeInBytes) override;
+    void getStateInformation (juce::MemoryBlock& destData) override {};
+    void setStateInformation (const void* data, int sizeInBytes) override {};
 
     //====== UI Component Callbacks ================================================
     void changeADSREnv(juce::ADSR::Parameters);

--- a/Subsynth.jucer
+++ b/Subsynth.jucer
@@ -19,6 +19,7 @@
       <FILE id="jCAFge" name="CustomSound.h" compile="0" resource="0" file="Source/CustomSound.h"/>
       <FILE id="eslnXH" name="CustomVoice.cpp" compile="1" resource="0" file="Source/CustomVoice.cpp"/>
       <FILE id="QTor4O" name="CustomVoice.h" compile="0" resource="0" file="Source/CustomVoice.h"/>
+      <FILE id="E6h2LH" name="WfVisualiser.h" compile="0" resource="0" file="Source/WfVisualiser.h"/>
     </GROUP>
   </MAINGROUP>
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" JUCE_VST3_CAN_REPLACE_VST2="0"/>


### PR DESCRIPTION
This PR:
- Adds docstring style definitions and parameter/return info for class methods.

Note: I didn't add anything for constructors specifically. I think I got everything else. Let me know what you would change or suggest changes directly!