### PR TITLE
Dynamically-sized GUI

### DIFF
--- a/Source/ADSRComponent.cpp
+++ b/Source/ADSRComponent.cpp
@@ -34,6 +34,7 @@ ADSRWheel::ADSRWheel (const ADSRWheel& oldObj)
 ADSRWheel& ADSRWheel::operator= (ADSRWheel& oldObj)
 {
     this->rotary.setRotaryParameters (oldObj.getParams());
+    this->rotaryLabel.setFont (getWidth());
     this->rotaryLabel.setText (oldObj.getLabelText(), juce::dontSendNotification);
 
     return *this;
@@ -114,6 +115,7 @@ void ADSRComponent::paint (juce::Graphics& g)
 void ADSRComponent::resized()
 {
     float width = getWidth();
+    
     attackRotary.setBounds (0.0000 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
     decayRotary.setBounds (0.2500 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
     sustainRotary.setBounds (0.5000 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);

--- a/Source/ADSRComponent.cpp
+++ b/Source/ADSRComponent.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "ADSRComponent.h"
+#include "PluginEditor.h"
 
 ADSRWheel::ADSRWheel()
 {
@@ -72,7 +73,8 @@ void ADSRWheel::setRotaryStyle()
 
 void ADSRWheel::resized()
 {
-    rotary.setBounds (10, 30, 75, 75);
+    float width = getWidth();
+    rotary.setBounds (0.1000 * width, 0.3000 * width, 0.7500 * width, 0.7500 * width);
 }
 
 //========================================================//
@@ -111,10 +113,11 @@ void ADSRComponent::paint (juce::Graphics& g)
 
 void ADSRComponent::resized()
 {
-    attackRotary.setBounds (0, 0, 100, 100);
-    decayRotary.setBounds (100, 0, 100, 100);
-    sustainRotary.setBounds (200, 0, 100, 100);
-    releaseRotary.setBounds (300, 0, 100, 100);
+    float width = getWidth();
+    attackRotary.setBounds (0.0000 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
+    decayRotary.setBounds (0.2500 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
+    sustainRotary.setBounds (0.5000 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
+    releaseRotary.setBounds (0.7500 * width, 0.0000 * width, 0.2500 * width, 0.2500 * width);
 }
 
 void ADSRComponent::sliderValueChanged (juce::Slider* slider)

--- a/Source/ADSRComponent.cpp
+++ b/Source/ADSRComponent.cpp
@@ -77,6 +77,7 @@ void ADSRWheel::setRotaryStyle()
 void ADSRWheel::resized()
 {
     float width = getWidth();
+    rotaryLabel.setFont (0.17 * width);
     rotary.setBounds (0.1000 * width, 0.3000 * width, 0.7500 * width, 0.7500 * width);
 }
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -16,7 +16,8 @@ SubsynthAudioProcessorEditor::SubsynthAudioProcessorEditor (SubsynthAudioProcess
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
     ///setSize (1000, 300);
-    setSize (850, 565);
+    
+    setSize (width, 0.665 * width);
 
     setGainStyle();
 
@@ -131,24 +132,24 @@ void SubsynthAudioProcessorEditor::resized()
     // sets the position and size of the slider with arguments (x, y, width, height)
     
     // Wave Selector
-    waveSelect.setBounds (10, 60, 90, 20);
+    waveSelect.setBounds (0.0118 * width, 0.0706 * width, 0.1059 * width, 0.0235 * width);
     
     // Keyboard
-    keyboard.setBounds (10, 205, getWidth() - 20, 150);
+    keyboard.setBounds (0.0118 * width, 0.2412 * width, 0.9765 * width, 0.1765 * width);
     
     // Filter Components
-    filterSelect.setBounds (110, 60, 100, 20);
-    filterCutoff.setBounds (110, 95, 100, 50);
-    filterRes.setBounds (110, 140, 100, 50);
+    filterSelect.setBounds (0.1294 * width, 0.0706 * width, 0.1176 * width, 0.0235 * width);
+    filterCutoff.setBounds (0.1294 * width, 0.1118 * width, 0.1176 * width, 0.0588 * width);
+    filterRes.setBounds (0.1294 * width, 0.1647 * width, 0.1176 * width, 0.0588 * width);
 
     // Waveform Visualiser
-    audioProcessor.wfVisualiser.setBounds (10, 360, getWidth() - 20, 200);
+    audioProcessor.wfVisualiser.setBounds (0.0118 * width, 0.4235 * width, 0.9765 * width, 0.2353 * width);
 
     // ADSR Components
-    adsrSliders.setBounds (220, 55, 400, 100);
+    adsrSliders.setBounds (0.2588 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
 
     // Gain Slider
-    gainSlide.setBounds (700, 50, 100, 100);
+    gainSlide.setBounds (0.8235 * width, 0.0588 * width, 0.1176 * width, 0.1176 * width);
 }
 
 // establish GUI configuration for gain rotary

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -110,21 +110,21 @@ void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
 
     // Main title
     g.setColour(juce::Colours::darkcyan);
-    g.drawLine(0.0f, 0.0f, getWidth(), 0.0f, 60);
+    g.drawLine(0.0000 * width, 0.0000 * width, 1.0000 * width, 0.0000 * width, 0.0706 * width);
     g.setColour (juce::Colours::white);
-    g.setFont (25.0f);
-    g.drawFittedText ("Subsynth", 0, 0, getWidth(), 30, juce::Justification::centred, 1);
+    g.setFont (0.0294 * width);
+    g.drawFittedText ("Subsynth", 0.0000 * width, 0.0000 * width, 1.0000 * width, 0.0353 * width, juce::Justification::centred, 1);
 
     // Component Titles
-    g.setFont (20.0f);
-    g.drawText ("Wave", 10, 30, 90, 30, juce::Justification::centred);
-    g.drawText ("Filter", 110, 30, 100, 30, juce::Justification::centred);
-    g.drawText ("ADSR Envelope", 220, 30, 400, 30, juce::Justification::centred);
+    g.setFont (0.0235 * width);
+    g.drawText ("Wave", 0.0118 * width, 0.0353 * width, 0.1059 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Filter", 0.1294 * width, 0.0353 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("ADSR Envelope", 0.2588 * width, 0.0353 * width, 0.4706 * width, 0.0353 * width, juce::Justification::centred);
 
     // Sub-component Titles
-    g.setFont (15.0f);
-    g.drawText ("Cutoff", 110, 80, 100, 30, juce::Justification::centred);
-    g.drawText ("Resonance", 110, 125, 100, 30, juce::Justification::centred);
+    g.setFont (0.0176 * width);
+    g.drawText ("Cutoff", 0.1294 * width, 0.0941 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Resonance", 0.1294 * width, 0.1471 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
 }
 
 void SubsynthAudioProcessorEditor::resized()

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -20,7 +20,7 @@ SubsynthAudioProcessorEditor::SubsynthAudioProcessorEditor (SubsynthAudioProcess
     setSize (width, 0.665 * width);
 
     setGainStyle();
-
+ 
     waveSelect.addItem ("Sine", 1);
     waveSelect.addItem ("Square", 2);
     waveSelect.addItem ("Saw", 3);
@@ -104,7 +104,10 @@ void SubsynthAudioProcessorEditor::filterChanged()
 
 //==============================================================================
 void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
-{
+{   
+    // dynamically obtain Width for resizing purposes
+    width = getWidth();
+
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 
@@ -131,6 +134,9 @@ void SubsynthAudioProcessorEditor::resized()
 {
     // sets the position and size of the slider with arguments (x, y, width, height)
     
+    // dynamically obtain Width for resizing purposes
+    width = getWidth();
+
     // Wave Selector
     waveSelect.setBounds (0.0118 * width, 0.0706 * width, 0.1059 * width, 0.0235 * width);
     
@@ -155,6 +161,9 @@ void SubsynthAudioProcessorEditor::resized()
 // establish GUI configuration for gain rotary
 void SubsynthAudioProcessorEditor::setGainStyle()
 {
+    // dynamically obtain width for resizing purposes
+    width = getWidth();
+
     gainSlide.setSliderStyle (juce::Slider::Rotary);
     gainSlide.setRotaryParameters (juce::MathConstants<float>::pi, (juce::MathConstants<float>::pi * 3), true);
     gainSlide.setVelocityBasedMode (true);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -125,14 +125,15 @@ void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
 
     // Component Titles
     g.setFont (0.0235 * width);
-    g.drawText ("Wave", 0.0118 * width, 0.0353 * width, 0.1059 * width, 0.0353 * width, juce::Justification::centred);
-    g.drawText ("Filter", 0.1294 * width, 0.0353 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
-    g.drawText ("ADSR Envelope", 0.2588 * width, 0.0353 * width, 0.4706 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Wave", 0.0618 * width, 0.0353 * width, 0.1059 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Filter", 0.1894 * width, 0.0353 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("ADSR Envelope", 0.3298 * width, 0.0353 * width, 0.4706 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Gain", 0.8235 * width, 0.0353 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
 
     // Sub-component Titles
     g.setFont (0.0176 * width);
-    g.drawText ("Cutoff", 0.1294 * width, 0.0941 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
-    g.drawText ("Resonance", 0.1294 * width, 0.1471 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Cutoff", 0.1894 * width, 0.0941 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
+    g.drawText ("Resonance", 0.1894 * width, 0.1471 * width, 0.1176 * width, 0.0353 * width, juce::Justification::centred);
 }
 
 void SubsynthAudioProcessorEditor::resized()
@@ -143,21 +144,21 @@ void SubsynthAudioProcessorEditor::resized()
     width = getWidth();
 
     // Wave Selector
-    waveSelect.setBounds (0.0118 * width, 0.0706 * width, 0.1059 * width, 0.0235 * width);
+    waveSelect.setBounds (0.0618 * width, 0.0706 * width, 0.1059 * width, 0.0235 * width);
     
     // Keyboard
     keyboard.setBounds (0.0118 * width, 0.2412 * width, 0.9765 * width, 0.1765 * width);
     
     // Filter Components
-    filterSelect.setBounds (0.1294 * width, 0.0706 * width, 0.1176 * width, 0.0235 * width);
-    filterCutoff.setBounds (0.1294 * width, 0.1118 * width, 0.1176 * width, 0.0588 * width);
-    filterRes.setBounds (0.1294 * width, 0.1647 * width, 0.1176 * width, 0.0588 * width);
+    filterSelect.setBounds (0.1894 * width, 0.0706 * width, 0.1176 * width, 0.0235 * width);
+    filterCutoff.setBounds (0.1894 * width, 0.1118 * width, 0.1176 * width, 0.0588 * width);
+    filterRes.setBounds (0.1894 * width, 0.1647 * width, 0.1176 * width, 0.0588 * width);
 
     // Waveform Visualiser
     audioProcessor.wfVisualiser.setBounds (0.0118 * width, 0.4235 * width, 0.9765 * width, 0.2353 * width);
 
     // ADSR Components
-    adsrSliders.setBounds (0.2588 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
+    adsrSliders.setBounds (0.3298 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
 
     // Gain Slider
     gainSlide.setBounds (0.8235 * width, 0.0588 * width, 0.1176 * width, 0.1176 * width);
@@ -180,5 +181,5 @@ void SubsynthAudioProcessorEditor::setGainStyle()
     gainSlide.setValue (-25.0);
     gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 0, 0);
     gainSlide.setTextValueSuffix (" dB");
-    adsrSliders.setBounds(0.2589 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
+    adsrSliders.setBounds (0.3298 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -164,8 +164,9 @@ void SubsynthAudioProcessorEditor::setGainStyle()
     gainSlide.setRange (juce::Range<double> (-50.0, 0.0), 2.0);
     gainSlide.setPopupDisplayEnabled (true, true, nullptr);
     gainSlide.setValue (-25.0);
-    gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 0, 0);
+    //gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 0, 0);
+    gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 100, 100);
     gainLabel.setText ("Gain(dB)", juce::dontSendNotification);
     gainLabel.attachToComponent (&gainSlide, true);
-    adsrSliders.setBounds (220, 55, 400, 100);
+    adsrSliders.setBounds (0.2589 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -166,6 +166,7 @@ void SubsynthAudioProcessorEditor::setGainStyle()
     gainSlide.setValue (-25.0);
     //gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 0, 0);
     gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 100, 100);
+    gainLabel.setFont (0.0176 * width);
     gainLabel.setText ("Gain(dB)", juce::dontSendNotification);
     gainLabel.attachToComponent (&gainSlide, true);
     adsrSliders.setBounds (0.2589 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -15,7 +15,6 @@ SubsynthAudioProcessorEditor::SubsynthAudioProcessorEditor (SubsynthAudioProcess
 {
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
-    ///setSize (1000, 300);
     
     setSize (width, 0.665 * width);
 
@@ -110,9 +109,6 @@ void SubsynthAudioProcessorEditor::filterChanged()
 //==============================================================================
 void SubsynthAudioProcessorEditor::paint (juce::Graphics& g)
 {   
-    // dynamically obtain Width for resizing purposes
-    width = getWidth();
-
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 
@@ -181,5 +177,4 @@ void SubsynthAudioProcessorEditor::setGainStyle()
     gainSlide.setValue (-25.0);
     gainSlide.setTextBoxStyle (juce::Slider::NoTextBox, false, 0, 0);
     gainSlide.setTextValueSuffix (" dB");
-    adsrSliders.setBounds (0.3298 * width, 0.0647 * width, 0.4706 * width, 0.1176 * width);
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -29,7 +29,7 @@ public:
     void resized() override;
  
 private:
-    int width = 1500; // sets the width of the plug-in window, with the rest dynamically sized
+    int width = 850; // sets the width of the plug-in window, with the rest dynamically sized
 
     void sliderValueChanged (juce::Slider* slider) override;
     void comboBoxChanged (juce::ComboBox* combobox) override;

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -29,6 +29,8 @@ public:
     void resized() override;
 
 private:
+    int width = 850;
+
     void sliderValueChanged (juce::Slider* slider) override;
     void comboBoxChanged (juce::ComboBox* combobox) override;
     void mouseDrag (const juce::MouseEvent& event) override;

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -27,7 +27,7 @@ public:
     //==============================================================================
     void paint (juce::Graphics&) override;
     void resized() override;
-
+ 
 private:
     int width = 850;
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -29,7 +29,7 @@ public:
     void resized() override;
  
 private:
-    int width = 850;
+    int width = 1500; // sets the width of the plug-in window, with the rest dynamically sized
 
     void sliderValueChanged (juce::Slider* slider) override;
     void comboBoxChanged (juce::ComboBox* combobox) override;

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -29,7 +29,8 @@ public:
     void resized() override;
  
 private:
-    int width = 850; // sets the width of the plug-in window, with the rest dynamically sized
+    // sets the initial width of the plug-in window, with other components dynamically sized
+    int width = 850;
 
     void sliderValueChanged (juce::Slider* slider) override;
     void comboBoxChanged (juce::ComboBox* combobox) override;


### PR DESCRIPTION
This pull request adds dynamic sizing to the GUI and updates the spatial positioning of components to be more aesthetically balanced.

Specifically, it implements:
- a width variable within the  SubsynthAudioProcessorEditor class to determine the starting width of the plug-in
- scale factors that size all elements of the plug-in using the current width of the window
- dynamic scaling that adjusts as the user changes the width of the plug-in window via dragging
- Wave, Filter, ADSR Envelope, and Gain components spaced more evenly across their area of the GUI

![image](https://user-images.githubusercontent.com/53282672/121132267-c6b32700-c7e5-11eb-83c3-647941c32949.png)
